### PR TITLE
Fix order of evaluation of the left-hand-side on assignment

### DIFF
--- a/bug_test.go
+++ b/bug_test.go
@@ -693,3 +693,10 @@ func Test_issue234(t *testing.T) {
 		`, "6,E")
 	})
 }
+
+func Test_issueAssignment(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+		test(`var a = 1; a += (a = 2)`, 3)
+	})
+}

--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -119,14 +119,15 @@ func (self *_runtime) cmpl_evaluate_nodeArrayLiteral(node *_nodeArrayLiteral) Va
 }
 
 func (self *_runtime) cmpl_evaluate_nodeAssignExpression(node *_nodeAssignExpression) Value {
+	var result Value
 
 	left := self.cmpl_evaluate_nodeExpression(node.left)
-	right := self.cmpl_evaluate_nodeExpression(node.right)
-	rightValue := right.resolve()
-
-	result := rightValue
 	if node.operator != token.ASSIGN {
-		result = self.calculateBinaryExpression(node.operator, left, rightValue)
+		leftValue := left.resolve()
+		rightValue := self.cmpl_evaluate_nodeExpression(node.right).resolve()
+		result = self.calculateBinaryExpression(node.operator, leftValue, rightValue)
+	} else {
+		result = self.cmpl_evaluate_nodeExpression(node.right).resolve()
 	}
 
 	self.putValue(left.reference(), result)
@@ -155,7 +156,7 @@ func (self *_runtime) cmpl_evaluate_nodeBinaryExpression(node *_nodeBinaryExpres
 		return right.resolve()
 	}
 
-	return self.calculateBinaryExpression(node.operator, leftValue, self.cmpl_evaluate_nodeExpression(node.right))
+	return self.calculateBinaryExpression(node.operator, leftValue, self.cmpl_evaluate_nodeExpression(node.right).resolve())
 }
 
 func (self *_runtime) cmpl_evaluate_nodeBinaryExpression_comparison(node *_nodeBinaryExpression) Value {

--- a/evaluate.go
+++ b/evaluate.go
@@ -52,16 +52,12 @@ func (self *_runtime) evaluateModulo(left float64, right float64) Value {
 	return Value{}
 }
 
-func (self *_runtime) calculateBinaryExpression(operator token.Token, left Value, right Value) Value {
-
-	leftValue := left.resolve()
-
+func (self *_runtime) calculateBinaryExpression(operator token.Token, leftValue Value, rightValue Value) Value {
 	switch operator {
 
 	// Additive
 	case token.PLUS:
 		leftValue = toPrimitive(leftValue)
-		rightValue := right.resolve()
 		rightValue = toPrimitive(rightValue)
 
 		if leftValue.IsString() || rightValue.IsString() {
@@ -70,18 +66,14 @@ func (self *_runtime) calculateBinaryExpression(operator token.Token, left Value
 			return toValue_float64(leftValue.float64() + rightValue.float64())
 		}
 	case token.MINUS:
-		rightValue := right.resolve()
 		return toValue_float64(leftValue.float64() - rightValue.float64())
 
 		// Multiplicative
 	case token.MULTIPLY:
-		rightValue := right.resolve()
 		return toValue_float64(leftValue.float64() * rightValue.float64())
 	case token.SLASH:
-		rightValue := right.resolve()
 		return self.evaluateDivide(leftValue.float64(), rightValue.float64())
 	case token.REMAINDER:
-		rightValue := right.resolve()
 		return toValue_float64(math.Mod(leftValue.float64(), rightValue.float64()))
 
 		// Logical
@@ -90,47 +82,39 @@ func (self *_runtime) calculateBinaryExpression(operator token.Token, left Value
 		if !left {
 			return falseValue
 		}
-		return toValue_bool(right.resolve().bool())
+		return toValue_bool(rightValue.bool())
 	case token.LOGICAL_OR:
 		left := leftValue.bool()
 		if left {
 			return trueValue
 		}
-		return toValue_bool(right.resolve().bool())
+		return toValue_bool(rightValue.bool())
 
 		// Bitwise
 	case token.AND:
-		rightValue := right.resolve()
 		return toValue_int32(toInt32(leftValue) & toInt32(rightValue))
 	case token.OR:
-		rightValue := right.resolve()
 		return toValue_int32(toInt32(leftValue) | toInt32(rightValue))
 	case token.EXCLUSIVE_OR:
-		rightValue := right.resolve()
 		return toValue_int32(toInt32(leftValue) ^ toInt32(rightValue))
 
 		// Shift
 		// (Masking of 0x1f is to restrict the shift to a maximum of 31 places)
 	case token.SHIFT_LEFT:
-		rightValue := right.resolve()
 		return toValue_int32(toInt32(leftValue) << (toUint32(rightValue) & 0x1f))
 	case token.SHIFT_RIGHT:
-		rightValue := right.resolve()
 		return toValue_int32(toInt32(leftValue) >> (toUint32(rightValue) & 0x1f))
 	case token.UNSIGNED_SHIFT_RIGHT:
-		rightValue := right.resolve()
 		// Shifting an unsigned integer is a logical shift
 		return toValue_uint32(toUint32(leftValue) >> (toUint32(rightValue) & 0x1f))
 
 	case token.INSTANCEOF:
-		rightValue := right.resolve()
 		if !rightValue.IsObject() {
 			panic(self.panicTypeError("Expecting a function in instanceof check, but got: %v", rightValue))
 		}
 		return toValue_bool(rightValue._object().hasInstance(leftValue))
 
 	case token.IN:
-		rightValue := right.resolve()
 		if !rightValue.IsObject() {
 			panic(self.panicTypeError())
 		}


### PR DESCRIPTION
In compound assignments, Otto wrongly evaluates the right-hand side before evaluating the left-hand side.

Reference: https://www.ecma-international.org/ecma-262/5.1/#sec-11.13.2
