### PR TITLE
`let`/`const` support

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -224,6 +224,8 @@ type (
 		LeftBrace  file.Idx
 		List       []Statement
 		RightBrace file.Idx
+
+		DeclarationList []Declaration
 	}
 
 	BranchStatement struct {
@@ -375,8 +377,10 @@ type (
 	}
 
 	VariableDeclaration struct {
-		Var  file.Idx
-		List []*VariableExpression
+		Var   file.Idx
+		List  []*VariableExpression
+		Block bool
+		Const bool
 	}
 )
 

--- a/cmpl_evaluate_statement.go
+++ b/cmpl_evaluate_statement.go
@@ -27,6 +27,22 @@ func (self *_runtime) cmpl_evaluate_nodeStatement(node _nodeStatement) Value {
 		labels := self.labels
 		self.labels = nil
 
+		if len(node.varList) > 0 || len(node.constList) > 0 {
+			outer := self.scope.lexical
+			self.scope.lexical = self.newDeclarationStash(outer)
+			defer func() {
+				self.scope.lexical = outer
+			}()
+
+			for _, name := range node.varList {
+				self.scope.lexical.createBinding(name, true, Value{})
+			}
+
+			for _, name := range node.constList {
+				self.scope.lexical.createImmutableBinding(name, Value{})
+			}
+		}
+
 		value := self.cmpl_evaluate_nodeStatementList(node.list)
 		switch value.kind {
 		case valueResult:

--- a/cmpl_parse.go
+++ b/cmpl_parse.go
@@ -210,6 +210,24 @@ func (cmpl *_compiler) parseStatement(in ast.Statement) _nodeStatement {
 		for i, value := range in.List {
 			out.list[i] = cmpl.parseStatement(value)
 		}
+
+		for _, value := range in.DeclarationList {
+			switch value := value.(type) {
+			case *ast.VariableDeclaration:
+				if value.Const {
+					for _, value := range value.List {
+						out.constList = append(out.constList, value.Name)
+					}
+				} else {
+					for _, value := range value.List {
+						out.varList = append(out.varList, value.Name)
+					}
+				}
+			default:
+				panic("invalid declaration")
+			}
+		}
+
 		return out
 
 	case *ast.BranchStatement:
@@ -521,7 +539,9 @@ type (
 	}
 
 	_nodeBlockStatement struct {
-		list []_nodeStatement
+		list      []_nodeStatement
+		varList   []string
+		constList []string
 	}
 
 	_nodeBranchStatement struct {

--- a/function_test.go
+++ b/function_test.go
@@ -343,3 +343,44 @@ func TestFunction_caller(t *testing.T) {
         `, true)
 	})
 }
+
+func TestFunction_let(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`
+(function() {
+	let bar = 123;
+	{ let bar = 456; }
+	return bar == 123;
+})()
+`, true)
+	})
+}
+
+func TestFunction_const(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`
+(function() {
+	const bar = 123;
+	{ const bar = 456; }
+	return bar == 123;
+})()
+`, true)
+
+		test(`
+(function() {
+	try {
+		const bar = 123;
+		bar = 1;
+		return false;
+	} catch(e) {
+		return true;
+	}
+})()
+`, true)
+
+	})
+}

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -208,7 +208,7 @@ func (self *_parser) parseVariableDeclaration(declarationList *[]*ast.VariableEx
 	return node
 }
 
-func (self *_parser) parseVariableDeclarationList(var_ file.Idx) []ast.Expression {
+func (self *_parser) parseVariableDeclarationList(var_ file.Idx, tk token.Token) []ast.Expression {
 
 	var declarationList []*ast.VariableExpression // Avoid bad expressions
 	var list []ast.Expression
@@ -229,8 +229,10 @@ func (self *_parser) parseVariableDeclarationList(var_ file.Idx) []ast.Expressio
 	}
 
 	self.scope.declare(&ast.VariableDeclaration{
-		Var:  var_,
-		List: declarationList,
+		Var:   var_,
+		List:  declarationList,
+		Block: tk == token.LET || tk == token.CONST,
+		Const: tk == token.CONST,
 	})
 
 	return list

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -430,9 +430,7 @@ func TestParserErr(t *testing.T) {
 			test("abc.class = 1", nil)
 			test("var class;", "(anonymous): Line 1:5 Unexpected reserved word")
 
-			test("const", "(anonymous): Line 1:1 Unexpected reserved word")
-			test("abc.const = 1", nil)
-			test("var const;", "(anonymous): Line 1:5 Unexpected reserved word")
+			test("var const;", "(anonymous): Line 1:5 Unexpected token const")
 
 			test("enum", "(anonymous): Line 1:1 Unexpected reserved word")
 			test("abc.enum = 1", nil)
@@ -465,9 +463,8 @@ func TestParserErr(t *testing.T) {
 			test(`abc.interface = 1`, nil)
 			test(`var interface;`, nil)
 
-			test(`let`, nil)
 			test(`abc.let = 1`, nil)
-			test(`var let;`, nil)
+			test(`var let;`, "(anonymous): Line 1:5 Unexpected token let")
 
 			test(`package`, nil)
 			test(`abc.package = 1`, nil)

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -302,12 +302,8 @@ func (self *_parser) parseFunction(declaration bool) *ast.FunctionLiteral {
 func (self *_parser) parseFunctionBlock(node *ast.FunctionLiteral) {
 	{
 		self.openScope()
-		inFunction := self.scope.inFunction
 		self.scope.inFunction = true
-		defer func() {
-			self.scope.inFunction = inFunction
-			self.closeScope()
-		}()
+		defer self.closeScope()
 		node.Body = self.parseBlockStatement()
 		node.DeclarationList = self.scope.declarationList
 	}

--- a/token/token_const.go
+++ b/token/token_const.go
@@ -80,6 +80,9 @@ const (
 	DO
 
 	VAR
+	LET
+	CONST
+
 	FOR
 	NEW
 	TRY
@@ -175,6 +178,8 @@ var token2string = [...]string{
 	IN:                          "in",
 	DO:                          "do",
 	VAR:                         "var",
+	LET:                         "let",
+	CONST:                       "const",
 	FOR:                         "for",
 	NEW:                         "new",
 	TRY:                         "try",
@@ -211,6 +216,12 @@ var keywordTable = map[string]_keyword{
 	},
 	"var": _keyword{
 		token: VAR,
+	},
+	"let": _keyword{
+		token: LET,
+	},
+	"const": _keyword{
+		token: CONST,
 	},
 	"for": _keyword{
 		token: FOR,
@@ -278,10 +289,6 @@ var keywordTable = map[string]_keyword{
 	"instanceof": _keyword{
 		token: INSTANCEOF,
 	},
-	"const": _keyword{
-		token:         KEYWORD,
-		futureKeyword: true,
-	},
 	"class": _keyword{
 		token:         KEYWORD,
 		futureKeyword: true,
@@ -312,11 +319,6 @@ var keywordTable = map[string]_keyword{
 		strict:        true,
 	},
 	"interface": _keyword{
-		token:         KEYWORD,
-		futureKeyword: true,
-		strict:        true,
-	},
-	"let": _keyword{
 		token:         KEYWORD,
 		futureKeyword: true,
 		strict:        true,

--- a/token/tokenfmt
+++ b/token/tokenfmt
@@ -72,7 +72,7 @@ BITWISE_NOT                    ~
 NOT_EQUAL                      !=
 STRICT_NOT_EQUAL               !==
 LESS_OR_EQUAL                  <=
-GREATER_OR_EQUAL               <=
+GREATER_OR_EQUAL               >=
 
 LEFT_PARENTHESIS               (
 LEFT_BRACKET                   [
@@ -93,6 +93,9 @@ IN
 DO
 
 VAR
+LET
+CONST
+
 FOR
 NEW
 TRY
@@ -181,7 +184,6 @@ _END_
     }
 
     for my $name (qw/
-        const
         class
         enum
         export
@@ -200,7 +202,6 @@ _END_
     for my $name (qw/
         implements
         interface
-        let
         package
         private
         protected


### PR DESCRIPTION
This is an in-progress implementation of `let`/`const` declarations from ES6.

- [ ] Fix scope around `for` statements
- [ ] Support `const` in `for` statements
- [ ] Fix temporal dead-zone
