### PR TITLE
Fix handling of array length

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -281,6 +281,19 @@ func TestArray_sliceArguments(t *testing.T) {
 	})
 }
 
+func TestArray_sliceNegativeLength(t *testing.T) {
+	tt(t, func() {
+		test, _ := test()
+
+		test(`
+            (function(){
+                return Array.prototype.slice.call({length:-1})
+            })();
+        `, "")
+	})
+
+}
+
 func TestArray_unshift(t *testing.T) {
 	tt(t, func() {
 		test, _ := test()

--- a/value_number.go
+++ b/value_number.go
@@ -90,8 +90,9 @@ const (
 	float_2_32   float64 = 4294967296.0
 	float_2_31   float64 = 2147483648.0
 	float_2_16   float64 = 65536.0
-	integer_2_32 int64   = 4294967296
-	integer_2_31 int64   = 2146483648
+	integer_2_53 int64   = 1 << 53
+	integer_2_32 int64   = 1 << 32
+	integer_2_31 int64   = 1 << 31
 	sqrt1_2      float64 = math.Sqrt2 / 2
 )
 
@@ -220,12 +221,7 @@ func (value Value) number() (number _number) {
 		return
 	}
 
-	integer := float64(0)
-	if float > 0 {
-		integer = math.Floor(float)
-	} else {
-		integer = math.Ceil(float)
-	}
+	integer := math.Trunc(float)
 
 	if float == integer {
 		number.kind = numberInteger
@@ -321,4 +317,17 @@ func toUint16(value Value) uint16 {
 		remainder = math.Ceil(remainder) + float_2_16
 	}
 	return uint16(remainder)
+}
+
+// toLength converts a Javascript value into a length of an array-like object.
+//
+// See https://www.ecma-international.org/ecma-262/6.0/#sec-tolength
+func toLength(value Value) int64 {
+	n := value.number().int64
+	if n > integer_2_53-1 {
+		n = integer_2_53 - 1
+	} else if n < 0 {
+		n = 0
+	}
+	return n
 }

--- a/value_test.go
+++ b/value_test.go
@@ -201,6 +201,26 @@ func Test_toUint16(t *testing.T) {
 	})
 }
 
+func Test_toLength(t *testing.T) {
+	tt(t, func() {
+		test := []interface{}{
+			0, int64(0),
+			-1, int64(0),
+			math.Inf(-1), int64(0),
+			math.NaN(), int64(0),
+			1.1, int64(1),
+			1 << 60, int64(1<<53 - 1),
+		}
+		for index := 0; index < len(test)/2; index++ {
+			// FIXME terst, Make strict again?
+			is(
+				toLength(toValue(test[index*2])),
+				test[index*2+1].(int64),
+			)
+		}
+	})
+}
+
 func Test_sameValue(t *testing.T) {
 	tt(t, func() {
 		is(sameValue(positiveZeroValue(), negativeZeroValue()), false)


### PR DESCRIPTION
Fix handling of array lengths in the builtin `Array.prototype` methods.

According to the spec, all these should be using the [`ToLength`](https://www.ecma-international.org/ecma-262/6.0/#sec-tolength) abstract operation, and need to support values up to `2**53-1`.