### PR TITLE
Optimize allocations

### DIFF
--- a/builtin_object.go
+++ b/builtin_object.go
@@ -59,7 +59,7 @@ func builtinObject_propertyIsEnumerable(call FunctionCall) Value {
 	propertyName := call.Argument(0).string()
 	thisObject := call.thisObject()
 	property := thisObject.getOwnProperty(propertyName)
-	if property != nil && property.enumerable() {
+	if !property.zero() && property.enumerable() {
 		return trueValue
 	}
 	return falseValue
@@ -108,10 +108,10 @@ func builtinObject_getOwnPropertyDescriptor(call FunctionCall) Value {
 
 	name := call.Argument(1).string()
 	descriptor := object.getOwnProperty(name)
-	if descriptor == nil {
+	if descriptor.zero() {
 		return Value{}
 	}
-	return toValue_object(call.runtime.fromPropertyDescriptor(*descriptor))
+	return toValue_object(call.runtime.fromPropertyDescriptor(descriptor))
 }
 
 func builtinObject_defineProperty(call FunctionCall) Value {
@@ -206,9 +206,9 @@ func builtinObject_seal(call FunctionCall) Value {
 	object := call.Argument(0)
 	if object := object._object(); object != nil {
 		object.enumerate(true, func(name string) bool {
-			if property := object.getOwnProperty(name); nil != property && property.configurable() {
+			if property := object.getOwnProperty(name); !property.zero() && property.configurable() {
 				property.configureOff()
-				object.defineOwnProperty(name, *property, true)
+				object.defineOwnProperty(name, property, true)
 			}
 			return true
 		})
@@ -242,7 +242,7 @@ func builtinObject_freeze(call FunctionCall) Value {
 	object := call.Argument(0)
 	if object := object._object(); object != nil {
 		object.enumerate(true, func(name string) bool {
-			if property, update := object.getOwnProperty(name), false; nil != property {
+			if property, update := object.getOwnProperty(name), false; !property.zero() {
 				if property.isDataDescriptor() && property.writable() {
 					property.writeOff()
 					update = true
@@ -252,7 +252,7 @@ func builtinObject_freeze(call FunctionCall) Value {
 					update = true
 				}
 				if update {
-					object.defineOwnProperty(name, *property, true)
+					object.defineOwnProperty(name, property, true)
 				}
 			}
 			return true

--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -186,10 +186,11 @@ func (self *_runtime) cmpl_evaluate_nodeCallExpression(node *_nodeCallExpression
 	this := Value{}
 	callee := self.cmpl_evaluate_nodeExpression(node.callee)
 
-	argumentList := []Value{}
+	var argumentList []Value
 	if withArgumentList != nil {
 		argumentList = self.toValueArray(withArgumentList...)
 	} else {
+		argumentList = make([]Value, 0, len(node.argumentList))
 		for _, argumentNode := range node.argumentList {
 			argumentList = append(argumentList, self.cmpl_evaluate_nodeExpression(argumentNode).resolve())
 		}

--- a/cmpl_evaluate_expression.go
+++ b/cmpl_evaluate_expression.go
@@ -203,12 +203,12 @@ func (self *_runtime) cmpl_evaluate_nodeCallExpression(node *_nodeCallExpression
 	name := ""
 	if rf != nil {
 		switch rf := rf.(type) {
-		case *_propertyReference:
+		case _propertyReference:
 			name = rf.name
 			object := rf.base
 			this = toValue_object(object)
 			eval = rf.name == "eval" // Possible direct eval
-		case *_stashReference:
+		case _stashReference:
 			// TODO ImplicitThisValue
 			name = rf.name
 			eval = rf.name == "eval" // Possible direct eval
@@ -281,9 +281,9 @@ func (self *_runtime) cmpl_evaluate_nodeNewExpression(node *_nodeNewExpression) 
 	name := ""
 	if rf != nil {
 		switch rf := rf.(type) {
-		case *_propertyReference:
+		case _propertyReference:
 			name = rf.name
-		case *_stashReference:
+		case _stashReference:
 			name = rf.name
 		default:
 			panic(rt.panicTypeError("Here be dragons"))

--- a/object.go
+++ b/object.go
@@ -28,12 +28,12 @@ func newObject(runtime *_runtime, class string) *_object {
 // 8.12
 
 // 8.12.1
-func (self *_object) getOwnProperty(name string) *_property {
+func (self *_object) getOwnProperty(name string) _property {
 	return self.objectClass.getOwnProperty(self, name)
 }
 
 // 8.12.2
-func (self *_object) getProperty(name string) *_property {
+func (self *_object) getProperty(name string) _property {
 	return self.objectClass.getProperty(self, name)
 }
 

--- a/property.go
+++ b/property.go
@@ -22,6 +22,11 @@ type _property struct {
 	mode  _propertyMode
 }
 
+func (self _property) zero() bool {
+	var zero _property
+	return self == zero
+}
+
 func (self _property) writable() bool {
 	return self.mode&modeWriteMask == modeWriteMask&modeOnMask
 }

--- a/runtime.go
+++ b/runtime.go
@@ -401,13 +401,13 @@ func (self *_runtime) convertCallParameter(v Value, t reflect.Type) reflect.Valu
 					}
 
 					for i := int64(0); i < l; i++ {
-						var p *_property
+						var p _property
 						if gslice {
 							p = goSliceGetOwnProperty(o, strconv.FormatInt(i, 10))
 						} else {
 							p = goArrayGetOwnProperty(o, strconv.FormatInt(i, 10))
 						}
-						if p == nil {
+						if p.zero() {
 							continue
 						}
 

--- a/stash.go
+++ b/stash.go
@@ -230,7 +230,7 @@ func (self *_dclStash) outer() _stash {
 }
 
 func (self *_dclStash) newReference(name string, strict bool, _ _at) _reference {
-	return &_stashReference{
+	return _stashReference{
 		name: name,
 		base: self,
 	}

--- a/type_arguments.go
+++ b/type_arguments.go
@@ -74,7 +74,7 @@ func argumentsGet(self *_object, name string) Value {
 	return objectGet(self, name)
 }
 
-func argumentsGetOwnProperty(self *_object, name string) *_property {
+func argumentsGetOwnProperty(self *_object, name string) _property {
 	property := objectGetOwnProperty(self, name)
 	if value, exists := self.value.(_argumentsObject).get(name); exists {
 		property.value = value

--- a/type_array.go
+++ b/type_array.go
@@ -96,7 +96,7 @@ func arrayDefineOwnProperty(self *_object, name string, descriptor _property, th
 		}
 		if index >= int64(length) {
 			lengthProperty.value = toValue_uint32(uint32(index + 1))
-			objectDefineOwnProperty(self, "length", *lengthProperty, false)
+			objectDefineOwnProperty(self, "length", lengthProperty, false)
 			return true
 		}
 	}

--- a/type_go_array.go
+++ b/type_go_array.go
@@ -54,10 +54,10 @@ func (self _goArrayObject) setValue(index int64, value Value) bool {
 	return true
 }
 
-func goArrayGetOwnProperty(self *_object, name string) *_property {
+func goArrayGetOwnProperty(self *_object, name string) _property {
 	// length
 	if name == "length" {
-		return &_property{
+		return _property{
 			value: toValue(reflect.Indirect(self.value.(*_goArrayObject).value).Len()),
 			mode:  0,
 		}
@@ -72,7 +72,7 @@ func goArrayGetOwnProperty(self *_object, name string) *_property {
 		if exists {
 			value = self.runtime.toValue(reflectValue.Interface())
 		}
-		return &_property{
+		return _property{
 			value: value,
 			mode:  object.propertyMode,
 		}

--- a/type_go_map.go
+++ b/type_go_map.go
@@ -46,22 +46,22 @@ func (self _goMapObject) toValue(value Value) reflect.Value {
 	return reflectValue
 }
 
-func goMapGetOwnProperty(self *_object, name string) *_property {
+func goMapGetOwnProperty(self *_object, name string) _property {
 	object := self.value.(*_goMapObject)
 	value := object.value.MapIndex(object.toKey(name))
 	if value.IsValid() {
-		return &_property{self.runtime.toValue(value.Interface()), 0111}
+		return _property{self.runtime.toValue(value.Interface()), 0111}
 	}
 
 	// Other methods
 	if method := self.value.(*_goMapObject).value.MethodByName(name); (method != reflect.Value{}) {
-		return &_property{
+		return _property{
 			value: self.runtime.toValue(method.Interface()),
 			mode:  0110,
 		}
 	}
 
-	return nil
+	return _property{}
 }
 
 func goMapEnumerate(self *_object, all bool, each func(string) bool) {

--- a/type_go_slice.go
+++ b/type_go_slice.go
@@ -44,10 +44,10 @@ func (self _goSliceObject) setValue(index int64, value Value) bool {
 	return true
 }
 
-func goSliceGetOwnProperty(self *_object, name string) *_property {
+func goSliceGetOwnProperty(self *_object, name string) _property {
 	// length
 	if name == "length" {
-		return &_property{
+		return _property{
 			value: toValue(self.value.(*_goSliceObject).value.Len()),
 			mode:  0,
 		}
@@ -61,7 +61,7 @@ func goSliceGetOwnProperty(self *_object, name string) *_property {
 		if exists {
 			value = self.runtime.toValue(reflectValue.Interface())
 		}
-		return &_property{
+		return _property{
 			value: value,
 			mode:  0110,
 		}
@@ -69,7 +69,7 @@ func goSliceGetOwnProperty(self *_object, name string) *_property {
 
 	// Other methods
 	if method := self.value.(*_goSliceObject).value.MethodByName(name); (method != reflect.Value{}) {
-		return &_property{
+		return _property{
 			value: self.runtime.toValue(method.Interface()),
 			mode:  0110,
 		}

--- a/type_go_struct.go
+++ b/type_go_struct.go
@@ -73,11 +73,11 @@ func (self _goStructObject) setValue(name string, value Value) bool {
 	return true
 }
 
-func goStructGetOwnProperty(self *_object, name string) *_property {
+func goStructGetOwnProperty(self *_object, name string) _property {
 	object := self.value.(*_goStructObject)
 	value := object.getValue(name)
 	if value.IsValid() {
-		return &_property{self.runtime.toValue(value.Interface()), 0110}
+		return _property{self.runtime.toValue(value.Interface()), 0110}
 	}
 
 	return objectGetOwnProperty(self, name)

--- a/type_reference.go
+++ b/type_reference.go
@@ -17,8 +17,8 @@ type _propertyReference struct {
 	at      _at
 }
 
-func newPropertyReference(rt *_runtime, base *_object, name string, strict bool, at _at) *_propertyReference {
-	return &_propertyReference{
+func newPropertyReference(rt *_runtime, base *_object, name string, strict bool, at _at) _propertyReference {
+	return _propertyReference{
 		runtime: rt,
 		name:    name,
 		strict:  strict,
@@ -27,18 +27,18 @@ func newPropertyReference(rt *_runtime, base *_object, name string, strict bool,
 	}
 }
 
-func (self *_propertyReference) invalid() bool {
+func (self _propertyReference) invalid() bool {
 	return self.base == nil
 }
 
-func (self *_propertyReference) getValue() Value {
+func (self _propertyReference) getValue() Value {
 	if self.base == nil {
 		panic(self.runtime.panicReferenceError("'%s' is not defined", self.name, self.at))
 	}
 	return self.base.get(self.name)
 }
 
-func (self *_propertyReference) putValue(value Value) string {
+func (self _propertyReference) putValue(value Value) string {
 	if self.base == nil {
 		return self.name
 	}
@@ -46,7 +46,7 @@ func (self *_propertyReference) putValue(value Value) string {
 	return ""
 }
 
-func (self *_propertyReference) delete() bool {
+func (self _propertyReference) delete() bool {
 	if self.base == nil {
 		// TODO Throw an error if strict
 		return true
@@ -56,7 +56,7 @@ func (self *_propertyReference) delete() bool {
 
 // ArgumentReference
 
-func newArgumentReference(runtime *_runtime, base *_object, name string, strict bool, at _at) *_propertyReference {
+func newArgumentReference(runtime *_runtime, base *_object, name string, strict bool, at _at) _propertyReference {
 	if base == nil {
 		panic(hereBeDragons())
 	}
@@ -69,20 +69,20 @@ type _stashReference struct {
 	base   _stash
 }
 
-func (self *_stashReference) invalid() bool {
+func (self _stashReference) invalid() bool {
 	return false // The base (an environment) will never be nil
 }
 
-func (self *_stashReference) getValue() Value {
+func (self _stashReference) getValue() Value {
 	return self.base.getBinding(self.name, self.strict)
 }
 
-func (self *_stashReference) putValue(value Value) string {
+func (self _stashReference) putValue(value Value) string {
 	self.base.setValue(self.name, value, self.strict)
 	return ""
 }
 
-func (self *_stashReference) delete() bool {
+func (self _stashReference) delete() bool {
 	if self.base == nil {
 		// This should never be reached, but just in case
 		return false

--- a/type_string.go
+++ b/type_string.go
@@ -98,15 +98,15 @@ func stringEnumerate(self *_object, all bool, each func(string) bool) {
 	objectEnumerate(self, all, each)
 }
 
-func stringGetOwnProperty(self *_object, name string) *_property {
-	if property := objectGetOwnProperty(self, name); property != nil {
+func stringGetOwnProperty(self *_object, name string) _property {
+	if property := objectGetOwnProperty(self, name); !property.zero() {
 		return property
 	}
 	// TODO Test a string of length >= +int32 + 1?
 	if index := stringToArrayIndex(name); index >= 0 {
 		if chr := stringAt(self.stringValue(), int(index)); chr != utf8.RuneError {
-			return &_property{toValue_string(string(chr)), 0}
+			return _property{toValue_string(string(chr)), 0}
 		}
 	}
-	return nil
+	return _property{}
 }

--- a/value.go
+++ b/value.go
@@ -280,9 +280,9 @@ func toValue_reflectValuePanic(value interface{}, kind reflect.Kind) {
 }
 
 func toValue(value interface{}) Value {
-	switch value := value.(type) {
+	switch v := value.(type) {
 	case Value:
-		return value
+		return v
 	case bool:
 		return Value{valueBoolean, value}
 	case int:
@@ -306,7 +306,7 @@ func toValue(value interface{}) Value {
 	case uint64:
 		return Value{valueNumber, value}
 	case float32:
-		return Value{valueNumber, float64(value)}
+		return Value{valueNumber, float64(v)}
 	case float64:
 		return Value{valueNumber, value}
 	case []uint16:
@@ -317,9 +317,9 @@ func toValue(value interface{}) Value {
 	case *_object:
 		return Value{valueObject, value}
 	case *Object:
-		return Value{valueObject, value.object}
+		return Value{valueObject, v.object}
 	case Object:
-		return Value{valueObject, value.object}
+		return Value{valueObject, v.object}
 	case _reference: // reference is an interface (already a pointer)
 		return Value{valueReference, value}
 	case _result:
@@ -328,51 +328,51 @@ func toValue(value interface{}) Value {
 		// TODO Ugh.
 		return Value{}
 	case reflect.Value:
-		for value.Kind() == reflect.Ptr {
+		for v.Kind() == reflect.Ptr {
 			// We were given a pointer, so we'll drill down until we get a non-pointer
 			//
 			// These semantics might change if we want to start supporting pointers to values transparently
 			// (It would be best not to depend on this behavior)
 			// FIXME: UNDEFINED
-			if value.IsNil() {
+			if v.IsNil() {
 				return Value{}
 			}
-			value = value.Elem()
+			v = v.Elem()
 		}
-		switch value.Kind() {
+		switch v.Kind() {
 		case reflect.Bool:
-			return Value{valueBoolean, bool(value.Bool())}
+			return Value{valueBoolean, bool(v.Bool())}
 		case reflect.Int:
-			return Value{valueNumber, int(value.Int())}
+			return Value{valueNumber, int(v.Int())}
 		case reflect.Int8:
-			return Value{valueNumber, int8(value.Int())}
+			return Value{valueNumber, int8(v.Int())}
 		case reflect.Int16:
-			return Value{valueNumber, int16(value.Int())}
+			return Value{valueNumber, int16(v.Int())}
 		case reflect.Int32:
-			return Value{valueNumber, int32(value.Int())}
+			return Value{valueNumber, int32(v.Int())}
 		case reflect.Int64:
-			return Value{valueNumber, int64(value.Int())}
+			return Value{valueNumber, int64(v.Int())}
 		case reflect.Uint:
-			return Value{valueNumber, uint(value.Uint())}
+			return Value{valueNumber, uint(v.Uint())}
 		case reflect.Uint8:
-			return Value{valueNumber, uint8(value.Uint())}
+			return Value{valueNumber, uint8(v.Uint())}
 		case reflect.Uint16:
-			return Value{valueNumber, uint16(value.Uint())}
+			return Value{valueNumber, uint16(v.Uint())}
 		case reflect.Uint32:
-			return Value{valueNumber, uint32(value.Uint())}
+			return Value{valueNumber, uint32(v.Uint())}
 		case reflect.Uint64:
-			return Value{valueNumber, uint64(value.Uint())}
+			return Value{valueNumber, uint64(v.Uint())}
 		case reflect.Float32:
-			return Value{valueNumber, float32(value.Float())}
+			return Value{valueNumber, float32(v.Float())}
 		case reflect.Float64:
-			return Value{valueNumber, float64(value.Float())}
+			return Value{valueNumber, float64(v.Float())}
 		case reflect.String:
-			return Value{valueString, string(value.String())}
+			return Value{valueString, string(v.String())}
 		default:
-			toValue_reflectValuePanic(value.Interface(), value.Kind())
+			toValue_reflectValuePanic(v.Interface(), v.Kind())
 		}
 	default:
-		return toValue(reflect.ValueOf(value))
+		return toValue(reflect.ValueOf(v))
 	}
 	// FIXME?
 	panic(newError(nil, "TypeError", 0, "invalid value: %v (%T)", value, value))


### PR DESCRIPTION
`_property`, `_propertyReference` and `_stashReference` are pure value objects that do not need to be pointers. In addition, the way `toValue` is implemented results in unecessary allocation in some branches because of the automatic type conversation.

Before:

```
% go test -run=dummy -bench=BenchmarkCryptoAES -benchtime=4x -benchmem .
goos: linux
goarch: amd64
pkg: github.com/robertkrimen/otto
BenchmarkCryptoAES-4           4        2454333159 ns/op        253395396 B/op   6016352 allocs/op
```

After:
```
% go test -run=dummy -bench=BenchmarkCryptoAES -benchtime=4x -benchmem .
goos: linux
goarch: amd64
pkg: github.com/robertkrimen/otto
BenchmarkCryptoAES-4           4        2601383646 ns/op        310277328 B/op   7766305 allocs/op
```

(-22% in number of allocations, -18% in allocation size)
